### PR TITLE
AndroidManifest: enable requestLegacyExternalStorage="true"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "ch.bailu.aat"
 
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 29
 
         versionCode 33
         versionName "v1.20"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:name="ch.bailu.aat.App"
         android:allowBackup="true"
         android:usesCleartextTraffic="true"


### PR DESCRIPTION
Starting with Android 11, apps are not anymore allowed to access
arbitrary storage locations.  This is a big problem for many apps,
including AAT, which doesn't use the storage directory assigned by the
Android APIs, but the hard-coded directory "aat_data".  In the long
term, AAT should use the former, but until that migration happens, we
need to enabe "requestLegacyExternalStorage", which works only with
targetSdkVersion 29.  The latest targetSdkVersion 30 doesn't allow
setting "requestLegacyExternalStorage".

For more details, see:

 https://developer.android.com/about/versions/11/privacy/storage
 https://developer.android.com/reference/android/R.attr#requestLegacyExternalStorage