### PR TITLE
BleSensorSDK18: remove the "connectingTimeout"

### DIFF
--- a/app/src/main/java/ch/bailu/aat/services/sensor/bluetooth_le/BleSensorSDK18.java
+++ b/app/src/main/java/ch/bailu/aat/services/sensor/bluetooth_le/BleSensorSDK18.java
@@ -50,15 +50,6 @@ public final class BleSensorSDK18 extends BluetoothGattCallback implements Senso
         }
     }, BleSensorsSDK18.SCAN_DURATION);
 
-
-    private final Timer connectingTimeout = new Timer(new Runnable() {
-        @Override
-        public void run() {
-            if (item.isConnecting())  close();
-        }
-    }, BleSensorsSDK18.CONNECTING_DURATION);
-
-
     public BleSensorSDK18(ServiceContext c, BluetoothDevice d, SensorList l, SensorListItem i) {
         synchronized (this) {
             sensorList = l;
@@ -82,7 +73,6 @@ public final class BleSensorSDK18 extends BluetoothGattCallback implements Senso
             } else {
                 execute.next(gatt);
                 scanningTimeout.kick();
-                connectingTimeout.kick();
                 item.setState(SensorItemState.CONNECTING);
                 item.setState(SensorItemState.SCANNING);
             }
@@ -266,7 +256,6 @@ public final class BleSensorSDK18 extends BluetoothGattCallback implements Senso
             closed = true;
 
             scanningTimeout.close();
-            connectingTimeout.close();
 
             updateListItemName();
 

--- a/app/src/main/java/ch/bailu/aat/services/sensor/bluetooth_le/BleSensorsSDK18.java
+++ b/app/src/main/java/ch/bailu/aat/services/sensor/bluetooth_le/BleSensorsSDK18.java
@@ -18,7 +18,6 @@ import ch.bailu.aat.util.Timer;
 public final class BleSensorsSDK18 extends Sensors {
 
     public final static long SCAN_DURATION = 10 * 1000;
-    public static final long CONNECTING_DURATION = 60 * 1000;
 
     private final ServiceContext scontext;
 


### PR DESCRIPTION
This "feature" is harmful because after waiting for 60 seconds for the
BLE sensor to appear, AAT ultimately gives up and never tries again.
This means that a heart rate sensor which got disconnected for more
than 60 seconds will cease to work for the rest of the ride unless the
user manually reconnects (which he only does if he notices the
problem).

There's no point in having this timeout; an application which tells
Android to connect to a certain BLE sensor can do so indefinitely, and
whenever the sensor becomes available, it will just work.  If it never
becomes available (if one rides a different bike or didn't equip the
heart rate sensor), that's no problem.  So let's just remove this!