### PR TITLE
tracker/AttributesCollector: disable LOG_INTERVAL

### DIFF
--- a/app/src/main/java/ch/bailu/aat/services/tracker/AttributesCollector.java
+++ b/app/src/main/java/ch/bailu/aat/services/tracker/AttributesCollector.java
@@ -13,7 +13,7 @@ import ch.bailu.aat.services.sensor.attributes.PowerAttributes;
 import ch.bailu.aat.services.sensor.attributes.StepCounterAttributes;
 
 public final class AttributesCollector {
-    private final static long LOG_INTERVAL = 3 * 1000;
+    private final static long LOG_INTERVAL = 0;
     private final static long SHORT_TIMEOUT = 2 * 1000;
     private final static long LONG_TIMEOUT = 10 * 1000;
 


### PR DESCRIPTION
By setting this to zero, AAT logs the extensions with each GPS fix,
instead of waiting 3 or 4 seconds.

This gives analysis software a better accuracy; not only because of
the finer-grained interval: if AAT records a sensor value, it's an
arbitrary value, and not the average since the last recorded value.
This means that the value may contain more noise than the sensor
actually provided.

And it solves a problem with Strava: if a GPS fix doesn't contain a
"cadence" value, Strava just uses the previous value; but if there's
no "power" value, Strava instead assumes zero, resulting in very low
(and bogus) average power values.

Let's drop this limitation - this causes GPX files to grow, but the
90ies are gone, and today, we have gigabytes of free storage for GPX
files.