### PR TITLE
AndroidManifest: move "required=false" to <uses-feature> element

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,14 +13,19 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-    <uses-permission android:name="android.permission.BLUETOOTH" android:required="false" />
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-
+    <!-- requesting permission android.permission.BLUETOOTH implies
+         that this app is only compatible with devices which have
+         Bluetooth; the following overrides this and declares that
+         Bluetooth is not strictly required -->
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false"/>
 
     <application
         android:requestLegacyExternalStorage="true"


### PR DESCRIPTION
The <uses-permission> element does not have a "required" attribute:

 https://developer.android.com/guide/topics/manifest/uses-permission-element

If an implicitly required feature shall not be strictly required, the
"required=false" attribute must be at the <uses-feature> element:

 https://developer.android.com/guide/topics/manifest/uses-feature-element