### PR TITLE
Inform user if offline theme isn't set

### DIFF
--- a/aat-android/src/main/res/values/strings.xml
+++ b/aat-android/src/main/res/values/strings.xml
@@ -392,6 +392,8 @@
     <string name ="error_integer_positive">"Weight must be between 1 and 999."</string>
     <string name="error_long">Wrong input, only numbers are allowed.\n\"%s\"</string>
     <string name ="error_met">"First Number must be between 0.0 to 20.0, followed by a space."</string>
+    <!-- needs translations -->
+    <string name ="error_no_map_file">"No map files found at "</string>
 
 
 </resources>

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/render/Configuration.java
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/render/Configuration.java
@@ -6,6 +6,7 @@ import org.mapsforge.map.rendertheme.XmlRenderTheme;
 
 import java.util.ArrayList;
 
+import ch.bailu.aat_lib.logger.AppLog;
 import ch.bailu.aat_lib.preferences.map.SolidMapsForgeDirectory;
 import ch.bailu.aat_lib.service.cache.ObjTileMapsForge;
 import ch.bailu.foc.Foc;
@@ -26,8 +27,16 @@ public final class Configuration {
             try {
                 renderer = new Renderer(theme, cache, mapFiles);
             } catch (Exception e) {
+                AppLog.e(renderer, e);
                 renderer = null;
             }
+        }
+        else
+        {
+            /* I've defined a string resource for this (which needs translations)
+             * but I can't find a way to access a string resource from here.
+             */
+            AppLog.e(this, "No map files found at " + mapDir.getPath());
         }
     }
 

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/render/Configuration.java
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/render/Configuration.java
@@ -69,8 +69,12 @@ public final class Configuration {
     }
 
     public void lockToRenderer(ObjTileMapsForge o) {
-        if (isConfigured() && themeID.equals(o.getThemeID())) {
-            renderer.addJob(o.getTile());
+        if (isConfigured()) {
+            if (themeID.equals(o.getThemeID())){
+                renderer.addJob(o.getTile());
+            } else {
+                AppLog.e("No valid theme for offline map - click on right edge and then on menu bars at top.");
+            }
         }
     }
 }


### PR DESCRIPTION
This is similar to my previous pull request. If the theme isn't set, or isn't set correctly, the user sees a track with no map behind it and no explanation. This pull request adds an explanation and a hint as to how to set it.