### PR TITLE
android/{Ble,Internal}Sensor: use SensorListItem.setState()

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/bluetooth_le/BleSensor.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/bluetooth_le/BleSensor.kt
@@ -49,8 +49,8 @@ class BleSensor(c: ServiceContext, d: BluetoothDevice, l: SensorList, i: SensorL
         } else {
             execute.next(gatt)
             scanningTimeout.kick(BleSensors.SCAN_DURATION) { if (item.isScanning) close() }
-            item.state = SensorItemState.CONNECTING
-            item.state = SensorItemState.SCANNING
+            item.setState(SensorItemState.CONNECTING)
+            item.setState(SensorItemState.SCANNING)
         }
         this.gatt = gatt
     }

--- a/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/internal/InternalSensorSDK23.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/internal/InternalSensorSDK23.kt
@@ -25,8 +25,8 @@ abstract class InternalSensorSDK23(
 
     init {
         if (item.lock(this)) {
-            item.state = SensorItemState.CONNECTING
-            item.state = SensorItemState.CONNECTED
+            item.setState(SensorItemState.CONNECTING)
+            item.setState(SensorItemState.CONNECTED)
             connector.connect()
             requestUpdates(this, sensor)
         }


### PR DESCRIPTION
Commit 2148e79c267c ("Sensor Java to Kotlin") switched from using SensorListItem.setState() to assigning the `state` field directly. This however skips the isNextStateValid() check, unconditionally leaving the state `SCANNING`.

This however broke BLE sensors: the next
BleSensor.onCharacteristicRead() call would then call executeNextAndSetState() and setNextState().  With `isScanning==true`, setNextState() would invoke close().

The simple fix is to revert to using setState().