### PR TITLE
.github/workflows/build-on-ubuntu.yml: run "apt-get update"

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y install libglib2.0-dev
+        sudo apt-get -y install --no-install-recommends libglib2.0-dev
 
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Package installation breaks if the package lists in the container image are outdated and the versions referenced therein have been removed from the Ubuntu mirrors meanwhile.