### PR TITLE
add a Beacon client

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/activities/MainActivity.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/activities/MainActivity.kt
@@ -20,6 +20,7 @@ import ch.bailu.aat_lib.dispatcher.DispatcherInterface
 import ch.bailu.aat_lib.dispatcher.source.CurrentLocationSource
 import ch.bailu.aat_lib.dispatcher.source.SensorSource
 import ch.bailu.aat_lib.dispatcher.source.TrackerSource
+import ch.bailu.aat_lib.dispatcher.source.BeaconSource
 import ch.bailu.aat_lib.dispatcher.usage.UsageTrackerAlwaysEnabled
 import ch.bailu.aat_lib.gpx.information.InfoID
 import ch.bailu.aat_lib.preferences.OnPreferencesChanged
@@ -62,6 +63,7 @@ class MainActivity : ActivityContext() {
     private fun createDispatcher(dispatcher: DispatcherInterface, appContext: AppContext) {
         val serviceContext = appContext.services
         dispatcher.addSource(TrackerSource(serviceContext, appContext.broadcaster, UsageTrackerAlwaysEnabled()))
+        dispatcher.addSource(BeaconSource(serviceContext, appContext.broadcaster, UsageTrackerAlwaysEnabled()))
         dispatcher.addSource(CurrentLocationSource(serviceContext, appContext.broadcaster))
         dispatcher.addSource(SensorSource(serviceContext, appContext.broadcaster, InfoID.SENSORS))
     }

--- a/aat-android/src/main/kotlin/ch/bailu/aat/activities/PreferencesActivity.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/activities/PreferencesActivity.kt
@@ -13,6 +13,7 @@ import ch.bailu.aat.views.description.mview.MultiView
 import ch.bailu.aat.views.layout.ContentView
 import ch.bailu.aat.views.preferences.GeneralPreferencesView
 import ch.bailu.aat.views.preferences.MapPreferencesView
+import ch.bailu.aat.views.preferences.NetworkPreferencesView
 import ch.bailu.aat.views.preferences.PresetPreferencesView
 import ch.bailu.aat_lib.gpx.information.InfoID
 import ch.bailu.aat_lib.preferences.OnPreferencesChanged
@@ -27,7 +28,7 @@ class PreferencesActivity : ActivityContext(), OnPreferencesChanged {
         /**
          * The number of pages not counting the "preset" pages.
          */
-        private const val N_BASE_PAGES = 2
+        private const val N_BASE_PAGES = 3
     }
 
     private val theme = AppTheme.preferences
@@ -67,6 +68,10 @@ class PreferencesActivity : ActivityContext(), OnPreferencesChanged {
         multiView.add(
             mapTilePreferences,
             getString(R.string.p_tiles)
+        )
+        multiView.add(
+            NetworkPreferencesView(this, theme),
+            "Network"
         )
 
         assert(multiView.pageCount() == N_BASE_PAGES);

--- a/aat-android/src/main/kotlin/ch/bailu/aat/services/OneService.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/services/OneService.kt
@@ -2,6 +2,7 @@ package ch.bailu.aat.services
 
 import android.content.Context
 import ch.bailu.aat.app.AndroidAppContext
+import ch.bailu.aat.preferences.Storage
 import ch.bailu.aat.preferences.location.AndroidSolidLocationProvider
 import ch.bailu.aat.services.sensor.SensorService
 import ch.bailu.aat_lib.service.tileremover.TileRemoverService
@@ -24,11 +25,14 @@ import ch.bailu.aat_lib.service.render.RenderServiceInterface
 import ch.bailu.aat_lib.service.sensor.SensorServiceInterface
 import ch.bailu.aat_lib.service.tracker.TrackerService
 import ch.bailu.aat_lib.service.tracker.TrackerServiceInterface
+import ch.bailu.aat_lib.service.beacon.BeaconService
+import ch.bailu.aat_lib.service.beacon.BeaconServiceInterface
 import ch.bailu.aat_lib.util.WithStatusText
 
 class OneService : AbsService() {
     private var location: LocationService? = null
     private var tracker: TrackerService? = null
+    private var beacon: BeaconService? = null
     private var background: BackgroundServiceInterface? = null
     private var iconMap: IconMapService? = null
     private var cache: CacheServiceInterface? = null
@@ -45,6 +49,9 @@ class OneService : AbsService() {
     @Synchronized
     override fun onDestroy() {
         onDestroyCalled()
+
+        beacon?.close()
+        beacon = null
 
         tracker?.close()
         tracker = null
@@ -155,6 +162,12 @@ class OneService : AbsService() {
     override fun getTrackerService(): TrackerServiceInterface {
         if (tracker == null) tracker = TrackerService(appContext.dataDirectory, StatusIcon(this), appContext.broadcaster,this)
         return tracker!!
+    }
+
+    @Synchronized
+    override fun getBeaconService(): BeaconServiceInterface {
+        if (beacon == null) beacon = BeaconService(this, appContext.broadcaster, Storage(this))
+        return beacon!!
     }
 
     @Synchronized

--- a/aat-android/src/main/kotlin/ch/bailu/aat/services/ServiceLink.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/services/ServiceLink.kt
@@ -18,6 +18,7 @@ import ch.bailu.aat_lib.service.location.LocationServiceInterface
 import ch.bailu.aat_lib.service.render.RenderServiceInterface
 import ch.bailu.aat_lib.service.sensor.SensorServiceInterface
 import ch.bailu.aat_lib.service.tracker.TrackerServiceInterface
+import ch.bailu.aat_lib.service.beacon.BeaconServiceInterface
 import java.io.Closeable
 
 
@@ -147,6 +148,10 @@ abstract class ServiceLink(private val context: Context) : ServiceContext, Servi
 
     override fun getTrackerService(): TrackerServiceInterface {
         return getService()!!.getTrackerService()
+    }
+
+    override fun getBeaconService(): BeaconServiceInterface {
+        return getService()!!.getBeaconService()
     }
 
     override fun getLocationService(): LocationServiceInterface {

--- a/aat-android/src/main/kotlin/ch/bailu/aat/views/preferences/NetworkPreferencesView.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/views/preferences/NetworkPreferencesView.kt
@@ -1,0 +1,39 @@
+package ch.bailu.aat.views.preferences
+
+import ch.bailu.aat.R
+import ch.bailu.aat.activities.ActivityContext
+import ch.bailu.aat.preferences.Storage
+import ch.bailu.aat.util.ui.theme.UiTheme
+import ch.bailu.aat.views.preferences.dialog.SolidTextInputDialog
+import ch.bailu.aat_lib.preferences.StorageInterface
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconEnabled
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconServer
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconKey
+
+class NetworkPreferencesView(acontext: ActivityContext, theme: UiTheme) :
+    VerticalScrollView(acontext) {
+    init {
+        val storage: StorageInterface = Storage(acontext)
+
+        add(TitleView(acontext, "Beacon", theme))
+
+        add(SolidCheckBox(acontext, SolidBeaconEnabled(storage), theme))
+
+        add(
+            SolidStringView(
+                acontext,
+                SolidBeaconServer(storage),
+                theme
+            )
+        )
+
+        add(
+            SolidTextInputView(
+                acontext,
+                SolidBeaconKey(storage),
+                SolidTextInputDialog.INTEGER,
+                theme
+            )
+        )
+    }
+}

--- a/aat-gtk/flatpak/gradle-sources.json
+++ b/aat-gtk/flatpak/gradle-sources.json
@@ -1534,6 +1534,27 @@
   },
   {
     "type": "file",
+    "url": "https://jitpack.io/com/github/MaxKellermann/beacon/v0.1/beacon-v0.1.jar",
+    "sha256": "5204cb1cd5367c86fcf0ca461091fe819b628154328025aea2f77bf92065dc59",
+    "dest": "maven-local/com/github/MaxKellermann/beacon/v0.1",
+    "dest-filename": "beacon-v0.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://jitpack.io/com/github/MaxKellermann/beacon/v0.1/beacon-v0.1.module",
+    "sha256": "fc9a6d0cbe50c9b5d68b7f8d4b9559c84998528ea583a5ffd3179d92d044124a",
+    "dest": "maven-local/com/github/MaxKellermann/beacon/v0.1",
+    "dest-filename": "beacon-v0.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://jitpack.io/com/github/MaxKellermann/beacon/v0.1/beacon-v0.1.pom",
+    "sha256": "3de827a9aff1bb5eb06a454bf214cb2bcb51c32bf347c991f8e5b96f4a4f345f",
+    "dest": "maven-local/com/github/MaxKellermann/beacon/v0.1",
+    "dest-filename": "beacon-v0.1.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/com/github/spotbugs/spotbugs-annotations/4.9.3/spotbugs-annotations-4.9.3.jar",
     "sha256": "13532bfe2f45fcd491432221df72d9cd0efb8f987c9245e12befa192c8925ce3",
     "dest": "maven-local/com/github/spotbugs/spotbugs-annotations/4.9.3",

--- a/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/service/GtkServices.kt
+++ b/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/service/GtkServices.kt
@@ -23,6 +23,8 @@ import ch.bailu.aat_lib.service.sensor.SensorServiceInterface
 import ch.bailu.aat_lib.service.tileremover.TileRemoverService
 import ch.bailu.aat_lib.service.tracker.TrackerService
 import ch.bailu.aat_lib.service.tracker.TrackerServiceInterface
+import ch.bailu.aat_lib.service.beacon.BeaconService
+import ch.bailu.aat_lib.service.beacon.BeaconServiceInterface
 
 class GtkServices (appContext: AppContext) : ServicesInterface {
     private val lazyLocationService by lazy { LocationService(
@@ -36,6 +38,12 @@ class GtkServices (appContext: AppContext) : ServicesInterface {
             GtkStatusIcon(),
             appContext.broadcaster,
             this
+    ) }
+
+    private val lazyBeaconService by lazy { BeaconService(
+            this,
+            appContext.broadcaster,
+            appContext.storage
     ) }
 
     private val lazyTileRemoverService by lazy {
@@ -90,6 +98,10 @@ class GtkServices (appContext: AppContext) : ServicesInterface {
 
     override fun getTrackerService(): TrackerServiceInterface {
         return lazyTrackerService
+    }
+
+    override fun getBeaconService(): BeaconServiceInterface {
+        return lazyBeaconService
     }
 
     override fun getIconMapService(): IconMapServiceInterface {

--- a/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/dialog/PreferencesDialog.kt
+++ b/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/dialog/PreferencesDialog.kt
@@ -3,6 +3,7 @@ package ch.bailu.aat_gtk.view.dialog
 import ch.bailu.aat_gtk.view.preferences.ActivityPreferencesPage
 import ch.bailu.aat_gtk.view.preferences.GeneralPreferencesPage
 import ch.bailu.aat_gtk.view.preferences.MapPreferencesPage
+import ch.bailu.aat_gtk.view.preferences.NetworkPreferencesPage
 import ch.bailu.aat_lib.app.AppContext
 import ch.bailu.gtk.adw.PreferencesDialog
 import ch.bailu.gtk.gtk.Application
@@ -15,6 +16,7 @@ object PreferencesDialog {
             window = PreferencesDialog().apply {
                 add(GeneralPreferencesPage(app, app.activeWindow, appContext).page)
                 add(MapPreferencesPage(appContext, app, app.activeWindow).page)
+                add(NetworkPreferencesPage(appContext).page)
                 add(ActivityPreferencesPage(appContext.storage).page)
 
                 onDestroy {

--- a/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/preferences/NetworkPreferencesPage.kt
+++ b/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/preferences/NetworkPreferencesPage.kt
@@ -1,0 +1,17 @@
+package ch.bailu.aat_gtk.view.preferences
+
+import ch.bailu.aat_lib.app.AppContext
+import ch.bailu.aat_lib.preferences.beacon.*
+import ch.bailu.gtk.adw.PreferencesGroup
+import ch.bailu.gtk.gtk.Application
+
+class NetworkPreferencesPage(appContext: AppContext) : PreferencesPageParent("Network", "network") {
+    init {
+        page.add(PreferencesGroup().apply {
+            setTitle("Beacon")
+            add(SolidBooleanSwitchView(SolidBeaconEnabled(appContext.storage)).layout)
+            add(SolidEntryView(SolidBeaconServer(appContext.storage)).layout)
+            add(SolidEntryView(SolidBeaconKey(appContext.storage)).layout)
+        })
+    }
+}

--- a/aat-lib/build.gradle.kts
+++ b/aat-lib/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
      *  For HtmlEscapers
      */
     implementation("com.google.guava:guava:33.5.0-jre")
+
+    implementation("com.github.MaxKellermann:beacon:v0.1")
 }
 
 testing {

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/broadcaster/AppBroadcaster.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/broadcaster/AppBroadcaster.kt
@@ -23,6 +23,7 @@ object AppBroadcaster {
     const val FILE_BACKGROUND_TASK_CHANGED = NAME_SPACE + "BACKGROUND_TASK"
     const val LOCATION_CHANGED = NAME_SPACE + "LOCATION"
     const val TRACKER = NAME_SPACE + "TRACKER"
+    const val BEACON = NAME_SPACE + "BEACON"
 
     /**
      * Info level namespace for message broadcaster

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/dispatcher/source/BeaconSource.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/dispatcher/source/BeaconSource.kt
@@ -1,0 +1,55 @@
+package ch.bailu.aat_lib.dispatcher.source
+
+import ch.bailu.aat_lib.broadcaster.AppBroadcaster
+import ch.bailu.aat_lib.broadcaster.BroadcastReceiver
+import ch.bailu.aat_lib.broadcaster.Broadcaster
+import ch.bailu.aat_lib.dispatcher.SourceInterface
+import ch.bailu.aat_lib.dispatcher.TargetInterface
+import ch.bailu.aat_lib.dispatcher.usage.UsageTrackerInterface
+import ch.bailu.aat_lib.gpx.information.GpxInformation
+import ch.bailu.aat_lib.gpx.information.InfoID
+import ch.bailu.aat_lib.service.ServicesInterface
+
+class BeaconSource(
+    private val services: ServicesInterface,
+    private val broadcaster: Broadcaster,
+    usageTracker: UsageTrackerInterface
+) : SourceInterface {
+    private var target = TargetInterface.NULL
+
+    init {
+        usageTracker.observe {
+            requestUpdate()
+        }
+    }
+
+    override fun setTarget(target: TargetInterface) {
+        this.target = target
+    }
+
+    private val onTrackChanged = BroadcastReceiver {
+        requestUpdate()
+    }
+
+    override fun requestUpdate() {
+        target.onContentUpdated(InfoID.BEACON, services.getBeaconService().getLoggerInformation())
+    }
+
+    override fun onPauseWithService() {
+        broadcaster.unregister(onTrackChanged)
+    }
+
+    override fun onDestroy() {}
+
+    override fun onResumeWithService() {
+        broadcaster.register(AppBroadcaster.BEACON, onTrackChanged)
+    }
+
+    override fun getIID(): Int {
+        return InfoID.BEACON
+    }
+
+    override fun getInfo(): GpxInformation {
+        return services.getBeaconService().getLoggerInformation()
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/information/InfoID.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/information/InfoID.kt
@@ -9,6 +9,7 @@ object InfoID {
     const val EDITOR_OVERLAY = 40 // TODO rename to EDITOR
     const val EDITOR_DRAFT = 41   // TODO rename to DRAFT
     const val LIST_SUMMARY = 5
+    const val BEACON = 50
     const val OVERLAY = 60
     const val UNSPECIFIED = -1
     const val SENSORS = 70

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/SolidSocketAddress.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/SolidSocketAddress.kt
@@ -1,0 +1,155 @@
+package ch.bailu.aat_lib.preferences
+
+import ch.bailu.aat_lib.exception.ValidationException
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+import com.google.common.net.InetAddresses
+
+open class SolidSocketAddress(
+    storage: StorageInterface,
+    key: String,
+    private val defaultPort: Int
+) : SolidString(storage, key) {
+
+    open fun getValue(): SocketAddress? {
+        val addressString = super.getValueAsString()
+        if (getStorage().isDefaultString(addressString)) {
+            return getDefaultValue()
+        }
+        return parseAddress(addressString)
+    }
+
+    fun setValue(address: SocketAddress) {
+        val addressString = formatAddress(address)
+        setValue(addressString)
+    }
+
+    override fun getValueAsString(): String {
+        val address = getValue() ?: getDefaultValue()
+        return if (address == null) {
+            ""
+        } else {
+            formatAddress(address)
+        }
+    }
+
+    override fun setValueFromString(string: String) {
+        val trimmed = string.trim()
+        if (trimmed.isEmpty()) {
+            setValue(getStorage().getDefaultString())
+            return
+        }
+
+        val address = parseAddress(trimmed)
+            ?: throw ValidationException("Invalid address format")
+        setValue(address)
+    }
+
+    override fun validate(s: String): Boolean {
+        val trimmed = s.trim()
+        if (trimmed.isEmpty()) return true
+        return parseAddress(trimmed) != null
+    }
+
+    /**
+     * Override this to provide a default address when none is configured
+     */
+    open fun getDefaultValue(): SocketAddress? {
+        return null
+    }
+
+    /**
+     * List of possible values to select from (for UI dropdowns/selection lists)
+     */
+    override fun buildSelection(list: ArrayList<String>): ArrayList<String> {
+        getDefaultValue()?.let { defaultAddress ->
+            list.add(formatAddress(defaultAddress))
+        }
+        return list
+    }
+
+    /**
+     * Parse a string to a SocketAddress.
+     */
+    private fun parseAddress(addressString: String): SocketAddress? {
+        if (addressString.isEmpty()) {
+            return null
+        }
+
+        try {
+            // Handle IPv6 with brackets: [::1]:5598 or [::1]
+            if (addressString.startsWith("[")) {
+                val closeBracket = addressString.indexOf(']')
+                if (closeBracket == -1) {
+                    return null
+                }
+                val host = addressString.substring(1, closeBracket)
+
+                // Check if there's a port after the closing bracket
+                val remainingPart = addressString.substring(closeBracket + 1)
+                val port = if (remainingPart.isEmpty()) {
+                    // No port specified, use default
+                    defaultPort
+                } else if (remainingPart.startsWith(":")) {
+                    // Port specified after colon
+                    val portStr = remainingPart.substring(1)
+                    portStr.toIntOrNull() ?: return null
+                } else {
+                    // Invalid format after closing bracket
+                    return null
+                }
+
+                if (port < 1 || port > 65535) return null
+                return InetSocketAddress(host, port)
+            }
+
+            // Handle IPv4 or simple hostnames: host:port or host
+            val lastColon = addressString.lastIndexOf(':')
+
+            val host: String
+            val port: Int
+
+            if (lastColon == -1) {
+                // No port specified, use default
+                host = addressString.trim()
+                port = defaultPort
+            } else {
+                // Port specified
+                host = addressString.substring(0, lastColon).trim()
+                val portStr = addressString.substring(lastColon + 1).trim()
+                port = portStr.toIntOrNull() ?: return null
+            }
+
+            if (host.isEmpty()) return null
+            if (port < 1 || port > 65535) return null
+
+            // Use InetSocketAddress constructor which handles DNS resolution
+            return InetSocketAddress(host, port)
+        } catch (e: Exception) {
+            return null
+        }
+    }
+    /**
+     * Format SocketAddress as string, handling both IPv4 and IPv6.
+     * Omits port if it matches the default port.
+     */
+    private fun formatAddress(address: SocketAddress): String {
+        return when (address) {
+            is InetSocketAddress -> {
+                val host = InetAddresses.toAddrString(address.address)
+                val port = address.port
+
+                if (port == defaultPort) {
+                    /* omit the port if it's the default port */
+                    host
+                } else if (host.contains(':')) {
+                    /* add brackets for IPv6 addresses if they contain colons */
+                    "[$host]:$port"
+                } else {
+                    "$host:$port"
+                }
+            }
+            else -> address.toString()
+        }
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconEnabled.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconEnabled.kt
@@ -1,0 +1,14 @@
+package ch.bailu.aat_lib.preferences.beacon
+
+import ch.bailu.aat_lib.preferences.SolidBoolean
+import ch.bailu.aat_lib.preferences.StorageInterface
+
+class SolidBeaconEnabled(storage: StorageInterface) : SolidBoolean(storage, KEY) {
+    override fun getLabel(): String {
+        return "Enabled"
+    }
+
+    companion object {
+        const val KEY = "BEACON_ENABLED"
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconKey.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconKey.kt
@@ -1,0 +1,14 @@
+package ch.bailu.aat_lib.preferences.beacon
+
+import ch.bailu.aat_lib.preferences.SolidLong
+import ch.bailu.aat_lib.preferences.StorageInterface
+
+class SolidBeaconKey(storage: StorageInterface) : SolidLong(storage, KEY) {
+    override fun getLabel(): String {
+        return "Key";
+    }
+
+    companion object {
+        const val KEY = "BEACON_KEY"
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconServer.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/preferences/beacon/SolidBeaconServer.kt
@@ -1,0 +1,22 @@
+package ch.bailu.aat_lib.preferences.beacon
+
+import ch.bailu.aat_lib.preferences.SolidSocketAddress
+import ch.bailu.aat_lib.preferences.StorageInterface
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+
+class SolidBeaconServer(storage: StorageInterface) : SolidSocketAddress(storage, KEY, DEFAULT_PORT) {
+    override fun getLabel(): String {
+        return "Server";
+    }
+
+    override fun getDefaultValue(): SocketAddress? {
+        return InetSocketAddress("138.201.185.127", DEFAULT_PORT)
+    }
+
+    companion object {
+        const val KEY = "BEACON_SERVER"
+
+        const val DEFAULT_PORT = 5598
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/ServicesInterface.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/ServicesInterface.kt
@@ -9,11 +9,13 @@ import ch.bailu.aat_lib.service.render.RenderServiceInterface
 import ch.bailu.aat_lib.service.sensor.SensorServiceInterface
 import ch.bailu.aat_lib.service.tileremover.TileRemoverService
 import ch.bailu.aat_lib.service.tracker.TrackerServiceInterface
+import ch.bailu.aat_lib.service.beacon.BeaconServiceInterface
 
 interface ServicesInterface {
     fun getLocationService(): LocationServiceInterface
     fun getSensorService(): SensorServiceInterface
     fun getTrackerService(): TrackerServiceInterface
+    fun getBeaconService(): BeaconServiceInterface
     fun getIconMapService(): IconMapServiceInterface
     fun getBackgroundService(): BackgroundServiceInterface
     fun getCacheService(): CacheServiceInterface

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/beacon/BeaconService.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/beacon/BeaconService.kt
@@ -1,0 +1,119 @@
+package ch.bailu.aat_lib.service.beacon
+
+import beacon.BeaconClient
+import ch.bailu.aat_lib.app.AppContext
+import ch.bailu.aat_lib.logger.AppLog
+import ch.bailu.aat_lib.broadcaster.AppBroadcaster
+import ch.bailu.aat_lib.broadcaster.BroadcastReceiver
+import ch.bailu.aat_lib.broadcaster.Broadcaster
+import ch.bailu.aat_lib.gpx.information.GpxInformation
+import ch.bailu.aat_lib.preferences.OnPreferencesChanged
+import ch.bailu.aat_lib.preferences.StorageInterface
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconEnabled
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconServer
+import ch.bailu.aat_lib.preferences.beacon.SolidBeaconKey
+import ch.bailu.aat_lib.service.ServicesInterface
+import ch.bailu.aat_lib.service.VirtualService
+import ch.bailu.aat_lib.service.background.BackgroundTask
+import ch.bailu.aat_lib.util.WithStatusText
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.SocketException
+
+/**
+ * Integrate the #BeaconClient into AAT as a #VirtualService.
+ */
+class BeaconService(
+    private val services: ServicesInterface,
+    private val broadcaster: Broadcaster,
+    private val storage: StorageInterface
+) : VirtualService(), WithStatusText, BeaconServiceInterface, OnPreferencesChanged {
+    private var client: BeaconClient? = null
+    private var location: GpxInformation = GpxInformation.NULL
+
+    private val onLocation = BroadcastReceiver { submit() }
+
+    init {
+        broadcaster.register(AppBroadcaster.LOCATION_CHANGED, onLocation)
+        storage.register(this)
+        maybeCreateClient(storage)
+    }
+
+    @Synchronized
+    override fun close() {
+        storage.unregister(this)
+        broadcaster.unregister(onLocation)
+        client?.close()
+        client = null
+    }
+
+    @Synchronized
+    private fun maybeCreateClient(storage: StorageInterface) {
+        client?.close()
+        client = null
+
+        if (!SolidBeaconEnabled(storage).isEnabled) {
+            AppLog.d(this, "Beacon is disabled")
+            return
+        }
+
+        val server = SolidBeaconServer(storage).getValue()
+        val key = SolidBeaconKey(storage).getValue()
+
+        if (server == null || key.toLong() == 0L) {
+            AppLog.w(this, "Beacon configuration incomplete")
+            return
+        }
+
+        try {
+            client = BeaconClient(server, key.toLong())
+            AppLog.i(this, "Beacon initialized, submitting to " + server)
+        } catch (e: SocketException) {
+            AppLog.e(this, e, "Beacon initialization failed")
+        }
+    }
+
+    override fun onPreferencesChanged(storage: StorageInterface, key: String) {
+        if (key.startsWith("BEACON_")) {
+            AppLog.d(this, "Beacon preferences changed")
+            maybeCreateClient(storage)
+        }
+    }
+
+    private fun submit(gpxLocation: GpxInformation) {
+        client?.let { beaconClient ->
+            services.getBackgroundService().process(BeaconSubmitTask(beaconClient, gpxLocation))
+        }
+    }
+
+    private fun submit() {
+        val locationService = services.getLocationService()
+        val newLocation = locationService.getLoggableLocationOrNull(location)
+        if (newLocation != null) {
+            location = newLocation
+            submit(location)
+        }
+    }
+
+    private class BeaconSubmitTask(
+        private val beaconClient: BeaconClient,
+        private val gpxLocation: GpxInformation
+    ) : BackgroundTask() {
+        override fun bgOnProcess(appContext: AppContext): Long {
+            try {
+                beaconClient.sendFix(gpxLocation.getLatitude(), gpxLocation.getLongitude())
+            } catch (e: IOException) {
+                // Ignore IOException - beacon submission failed
+            }
+            return 0 // No size to report for network operations
+        }
+    }
+
+    override fun appendStatusText(builder: StringBuilder) {
+        builder.append("<p>Beacon!</p>")
+    }
+
+    override fun getLoggerInformation(): GpxInformation {
+        return location
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/beacon/BeaconServiceInterface.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/beacon/BeaconServiceInterface.kt
@@ -1,0 +1,7 @@
+package ch.bailu.aat_lib.service.beacon
+
+import ch.bailu.aat_lib.gpx.information.GpxInformation
+
+interface BeaconServiceInterface {
+    fun getLoggerInformation(): GpxInformation
+}

--- a/aat-lib/src/test/kotlin/ch/bailu/aat_lib/mock/MockServices.kt
+++ b/aat-lib/src/test/kotlin/ch/bailu/aat_lib/mock/MockServices.kt
@@ -11,6 +11,7 @@ import ch.bailu.aat_lib.service.render.RenderServiceInterface
 import ch.bailu.aat_lib.service.sensor.SensorServiceInterface
 import ch.bailu.aat_lib.service.tileremover.TileRemoverService
 import ch.bailu.aat_lib.service.tracker.TrackerServiceInterface
+import ch.bailu.aat_lib.service.beacon.BeaconServiceInterface
 
 class MockServices : ServicesInterface {
     override fun getLocationService(): LocationServiceInterface {
@@ -22,6 +23,10 @@ class MockServices : ServicesInterface {
     }
 
     override fun getTrackerService(): TrackerServiceInterface {
+        TODO("Not yet implemented")
+    }
+
+    override fun getBeaconService(): BeaconServiceInterface {
         TODO("Not yet implemented")
     }
 

--- a/aat-lib/src/test/kotlin/ch/bailu/aat_lib/preferences/SolidSocketAddressTest.kt
+++ b/aat-lib/src/test/kotlin/ch/bailu/aat_lib/preferences/SolidSocketAddressTest.kt
@@ -1,0 +1,118 @@
+package ch.bailu.aat_lib.preferences
+
+import ch.bailu.aat_lib.mock.MockStorage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.net.InetSocketAddress
+
+class SolidSocketAddressTest {
+
+    @Test
+    fun testDefaultPortParsing() {
+        val storage = MockStorage()
+        val socketAddress = SolidSocketAddress(storage, "test_key", 5598)
+
+        // Test IPv4 without port (should default to 5598)
+        storage.writeString("test_key", "127.0.0.1")
+        val result1 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("127.0.0.1", result1.hostString)
+        assertEquals(5598, result1.port)
+
+        // Test hostname without port (should default to 5598)
+        storage.writeString("test_key", "localhost")
+        val result2 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("localhost", result2.hostString)
+        assertEquals(5598, result2.port)
+
+        // Test IPv6 without port (should default to 5598)
+        storage.writeString("test_key", "[::1]")
+        val result3 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("0:0:0:0:0:0:0:1", result3.hostString)
+        assertEquals(5598, result3.port)
+
+        // Test IPv6 with brackets and no port (should default to 5598)
+        storage.writeString("test_key", "[2001:db8::1]")
+        val result4 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("2001:db8:0:0:0:0:0:1", result4.hostString)
+        assertEquals(5598, result4.port)
+    }
+
+    @Test
+    fun testExplicitPortParsing() {
+        val storage = MockStorage()
+        val socketAddress = SolidSocketAddress(storage, "test_key", 5598)
+
+        // Test IPv4 with explicit port
+        storage.writeString("test_key", "127.0.0.1:8080")
+        val result1 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("127.0.0.1", result1.hostString)
+        assertEquals(8080, result1.port)
+
+        // Test IPv6 with explicit port
+        storage.writeString("test_key", "[::1]:8080")
+        val result2 = socketAddress.getValue() as InetSocketAddress
+        assertEquals("0:0:0:0:0:0:0:1", result2.hostString)
+        assertEquals(8080, result2.port)
+    }
+
+    @Test
+    fun testFormatting() {
+        val storage = MockStorage()
+        val socketAddress = SolidSocketAddress(storage, "test_key", 5598)
+
+        // Test IPv4 with default port (should omit port)
+        socketAddress.setValue(InetSocketAddress("127.0.0.1", 5598))
+        assertEquals("127.0.0.1", storage.readString("test_key"))
+
+        // Test IPv4 with custom port (should include port)
+        socketAddress.setValue(InetSocketAddress("127.0.0.1", 8080))
+        assertEquals("127.0.0.1:8080", storage.readString("test_key"))
+
+        // Test IPv6 with default port (should omit port and brackets)
+        socketAddress.setValue(InetSocketAddress("::1", 5598))
+        System.err.println(storage.readString("test_key"))
+        assertEquals("::1", storage.readString("test_key"))
+
+        // Test IPv6 with custom port (should include port)
+        socketAddress.setValue(InetSocketAddress("::1", 8080))
+        assertEquals("[::1]:8080", storage.readString("test_key"))
+    }
+
+    @Test
+    fun testValidation() {
+        val storage = MockStorage()
+        val socketAddress = SolidSocketAddress(storage, "test_key", 5598)
+
+        // Valid addresses
+        assertTrue(socketAddress.validate("127.0.0.1"))
+        assertTrue(socketAddress.validate("localhost"))
+        assertTrue(socketAddress.validate("[::1]"))
+        assertTrue(socketAddress.validate("127.0.0.1:8080"))
+        assertTrue(socketAddress.validate("[::1]:8080"))
+        assertTrue(socketAddress.validate(""))  // Empty is valid (uses default)
+
+        // Invalid addresses
+        assertFalse(socketAddress.validate("127.0.0.1:99999"))  // Port too high
+        assertFalse(socketAddress.validate("[::1]:0"))          // Port too low
+        assertFalse(socketAddress.validate("[::1"))            // Missing closing bracket
+    }
+
+    @Test
+    fun testDifferentDefaultPorts() {
+        val storage = MockStorage()
+        val socketAddress1234 = SolidSocketAddress(storage, "test_key", 1234)
+
+        // Test with different default port
+        storage.writeString("test_key", "localhost")
+        val result = socketAddress1234.getValue() as InetSocketAddress
+        assertEquals("localhost", result.hostString)
+        assertEquals(1234, result.port)
+
+        // Test formatting with different default port
+        socketAddress1234.setValue(InetSocketAddress("127.0.0.1", 1234))
+        assertEquals("127.0.0.1", storage.readString("test_key"))  // Should omit port
+
+        socketAddress1234.setValue(InetSocketAddress("127.0.0.1", 5598))
+        assertEquals("127.0.0.1:5598", storage.readString("test_key"))  // Should include port
+    }
+}


### PR DESCRIPTION
My service for sharing live GPS locations, see
     https://github.com/MaxKellermann/beacon
    
 A demo server is running on beacon.blarg.de; its IP address is currently 138.201.185.127, and this is the default value.  There should be a way to use a DNS resolver, but that's a task for another day.

(I have posted this a long ago as PR https://github.com/bailuk/AAT/pull/85 but didn't manage to finish it back then; I have now made a configuration page for it, and it's disabled by default. I hope we can get it ready for merging soon.)