### PR TITLE
android/BleScanner: include 0x1818 (cycling power) in the ScanFilter

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/bluetooth_le/BleScanner.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/services/sensor/bluetooth_le/BleScanner.kt
@@ -27,7 +27,10 @@ class BleScanner internal constructor(sensors: BleSensors) : AbsBleScanner(senso
     private val cscFilter = ScanFilter.Builder()
         .setServiceUuid(ParcelUuid.fromString("00001816-0000-1000-8000-00805f9b34fb"))
         .build()
-    private val filters = ArrayList(listOf(hrFilter, cscFilter))
+    private val powerFilter = ScanFilter.Builder()
+        .setServiceUuid(ParcelUuid.fromString("00001818-0000-1000-8000-00805f9b34fb"))
+        .build()
+    private val filters = ArrayList(listOf(hrFilter, cscFilter, powerFilter))
 
     override fun start() {
         val scanner = adapter.bluetoothLeScanner


### PR DESCRIPTION
When I wrote commit 32c590f820941722 ("sensor/ble/CyclingPower: support for cycle power meters"), I forgot to include 0x1818 in the BleScanner filter, and thus only power meters could ever work that were paired.

This fix allows using power meters that are not paired.