### PR TITLE
AverageSpeedDescription: show two decimals

### DIFF
--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/AverageSpeedDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/AverageSpeedDescription.kt
@@ -4,7 +4,7 @@ import ch.bailu.aat_lib.gpx.information.GpxInformation
 import ch.bailu.aat_lib.preferences.StorageInterface
 import ch.bailu.aat_lib.resources.Res
 
-open class AverageSpeedDescription(storage: StorageInterface) : SpeedDescription(storage) {
+open class AverageSpeedDescription(storage: StorageInterface) : SpeedDescription(storage, FormatDisplay.f().decimal2) {
     override fun getLabel(): String {
         return Res.str().average()
     }

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/SpeedDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/SpeedDescription.kt
@@ -1,9 +1,10 @@
 package ch.bailu.aat_lib.description
 
+import java.text.NumberFormat
 import ch.bailu.aat_lib.preferences.StorageInterface
 import ch.bailu.aat_lib.preferences.general.SolidUnit
 
-abstract class SpeedDescription(storage: StorageInterface) : FloatDescription() {
+abstract class SpeedDescription(storage: StorageInterface, private val format: NumberFormat=FormatDisplay.f().decimal1) : FloatDescription() {
     private val sunit: SolidUnit = SolidUnit(storage)
 
     override fun getUnit(): String {
@@ -13,7 +14,7 @@ abstract class SpeedDescription(storage: StorageInterface) : FloatDescription() 
     override fun getValue(): String {
         val speedFactor = sunit.speedFactor
         val speed = cache* speedFactor
-        return FormatDisplay.f().decimal1.format(speed.toDouble())
+        return format.format(speed.toDouble())
     }
 
     fun getSpeedDescription(value: Float): String {


### PR DESCRIPTION
Add a `format` parameter to the SpeedDescription constructor, defaulting to one decimal (like before).  Change the `AverageSpeedDescription` constructor to explicitly pass a two-decimal format object instead, because having some more accuracy on the average speed helps me estimate how I perform at any time.