### PR TITLE
aat-android/FileMenu: add "resume" button

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/menus/AbsFileMenu.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/menus/AbsFileMenu.kt
@@ -3,6 +3,8 @@ package ch.bailu.aat.menus
 import android.view.Menu
 import ch.bailu.aat.R
 import ch.bailu.aat.activities.ActivityContext
+import ch.bailu.aat.activities.CockpitSplitActivity
+import ch.bailu.aat.app.ActivitySwitcher
 import ch.bailu.aat.util.fs.AndroidFileAction
 import ch.bailu.aat_lib.resources.Res
 import ch.bailu.aat_lib.util.fs.AppDirectory
@@ -51,6 +53,10 @@ abstract class AbsFileMenu(private val aContext: ActivityContext, protected val 
         }
         add(menu, R.string.file_reload) { FileAction.reloadPreview(aContext.appContext, file) }
         add(menu, R.string.file_mock) { FileAction.useForMockLocation(aContext.appContext, file) }
+        add(menu, R.string.file_resume) {
+            FileAction.resumeTracker(aContext.appContext, file)
+            ActivitySwitcher.start(aContext, CockpitSplitActivity::class.java)
+        }
     }
 
     protected fun inflateOverlay(menu: Menu) {

--- a/aat-android/src/main/res/values/strings.xml
+++ b/aat-android/src/main/res/values/strings.xml
@@ -282,6 +282,7 @@
     <string name="file_rename">Rename file</string>
     <string name="file_overlay">Use as overlay</string>
     <string name="file_mock">Use for mock location</string>
+    <string name="file_resume">Resume from file</string>
     <string name="file_delete_ask">Delete file?</string>
     <string name="file_send">Send…</string>
     <string name="file_view">View/Edit…</string>

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/resources/generated/Strings.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/resources/generated/Strings.kt
@@ -306,6 +306,8 @@ open class Strings {
 
     open fun file_mock(): String = "Use for mock location"
 
+    open fun file_resume(): String = "Resume from file"
+
     open fun file_delete_ask(): String = "Delete file?"
 
     open fun file_send(): String = "Send…"

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/Logger.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/Logger.kt
@@ -1,5 +1,6 @@
 package ch.bailu.aat_lib.service.tracker
 
+import ch.bailu.aat_lib.gpx.GpxList
 import ch.bailu.aat_lib.gpx.information.GpxInformation
 import ch.bailu.aat_lib.gpx.information.StateID
 import ch.bailu.aat_lib.gpx.attributes.GpxAttributes
@@ -11,6 +12,9 @@ abstract class Logger : GpxInformation(), Closeable {
     private var state = StateID.OFF
 
     open fun logPause() {}
+
+    @Throws(IOException::class)
+    abstract fun logAllFrom(list: GpxList)
 
     @Throws(IOException::class)
     abstract fun log(tp: GpxPointInterface, attr: GpxAttributes)
@@ -30,6 +34,7 @@ abstract class Logger : GpxInformation(), Closeable {
 
     companion object {
         val NULL_LOGGER: Logger = object : Logger() {
+            override fun logAllFrom(list: GpxList) {}
             override fun log(tp: GpxPointInterface, attr: GpxAttributes) {}
             override fun flush() {}
         }

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackLogger.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackLogger.kt
@@ -2,6 +2,7 @@ package ch.bailu.aat_lib.service.tracker
 
 import ch.bailu.aat_lib.file.xml.writer.GpxListWriter
 import ch.bailu.aat_lib.gpx.GpxList
+import ch.bailu.aat_lib.gpx.GpxListIterator
 import ch.bailu.aat_lib.gpx.GpxPoint
 import ch.bailu.aat_lib.gpx.GpxPointNode
 import ch.bailu.aat_lib.gpx.attributes.GpxAttributes
@@ -49,19 +50,45 @@ class TrackLogger(val sdirectory: SolidDataDirectory, private val presetIndex: I
         }
     }
 
-    @Throws(IOException::class)
-    override fun log(tp: GpxPointInterface, attr: GpxAttributes) {
+    private fun append(tp: GpxPointInterface, attr: GpxAttributes) {
         if (requestSegment) {
             requestSegment = false
             track.appendToNewSegment(GpxPoint(tp), attr)
         } else {
             track.appendToCurrentSegment(GpxPoint(tp), attr)
         }
+    }
+
+    private fun postAppend() {
         val node = track.pointList.last
         if (node is GpxPointNode) {
             setVisibleTrackPoint(node)
         }
         writer.writeNewPoints()
+    }
+
+    @Throws(IOException::class)
+    override fun logAllFrom(src: GpxList) {
+        requestSegment = true
+
+        val i = GpxListIterator(src)
+        while (i.nextPoint()) {
+            if (i.isFirstInSegment)
+                requestSegment = true
+
+            val point = i.getPoint()
+            append(point, point.getAttributes())
+        }
+
+        requestSegment = true
+
+        postAppend()
+    }
+
+    @Throws(IOException::class)
+    override fun log(tp: GpxPointInterface, attr: GpxAttributes) {
+        append(tp, attr)
+        postAppend()
     }
 
     /**

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackerService.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackerService.kt
@@ -3,7 +3,9 @@ package ch.bailu.aat_lib.service.tracker
 import ch.bailu.aat_lib.broadcaster.AppBroadcaster
 import ch.bailu.aat_lib.broadcaster.BroadcastReceiver
 import ch.bailu.aat_lib.broadcaster.Broadcaster
+import ch.bailu.aat_lib.gpx.GpxList
 import ch.bailu.aat_lib.gpx.information.GpxInformation
+import ch.bailu.aat_lib.gpx.information.StateID
 import ch.bailu.aat_lib.preferences.system.SolidDataDirectory
 import ch.bailu.aat_lib.service.ServicesInterface
 import ch.bailu.aat_lib.service.VirtualService
@@ -49,6 +51,15 @@ class TrackerService(
     override fun close() {
         internal.close()
         broadcaster.unregister(onLocation)
+    }
+
+    @Synchronized
+    override fun resumeLogger(old: GpxList) {
+        if (internal.logger.getState() != StateID.OFF)
+            throw IllegalStateException("Logger is already on")
+
+        onStartStop()
+        internal.logger.logAllFrom(old)
     }
 
     @Synchronized

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackerServiceInterface.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/service/tracker/TrackerServiceInterface.kt
@@ -1,8 +1,11 @@
 package ch.bailu.aat_lib.service.tracker
 
+import ch.bailu.aat_lib.gpx.GpxList
 import ch.bailu.aat_lib.gpx.information.GpxInformationProvider
 
 interface TrackerServiceInterface : StateInterface,
     GpxInformationProvider {
     fun getPresetIndex(): Int
+
+    fun resumeLogger(old: GpxList)
 }

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/util/fs/FileAction.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/util/fs/FileAction.kt
@@ -2,6 +2,9 @@ package ch.bailu.aat_lib.util.fs
 
 import ch.bailu.aat_lib.app.AppContext
 import ch.bailu.aat_lib.broadcaster.AppBroadcaster
+import ch.bailu.aat_lib.file.xml.parser.gpx.GpxListReaderXml
+import ch.bailu.aat_lib.gpx.attributes.AutoPause
+import ch.bailu.aat_lib.gpx.information.StateID
 import ch.bailu.aat_lib.logger.AppLog
 import ch.bailu.aat_lib.preferences.file_list.SolidDirectoryQuery
 import ch.bailu.aat_lib.preferences.location.SolidMockLocationFile
@@ -36,6 +39,18 @@ object FileAction {
         if (file.canRead()) SolidMockLocationFile(context.storage).setValue(file.path) else logErrorNoAccess(
             file
         )
+    }
+
+    fun resumeTracker(context: AppContext, file: Foc) {
+        val trackerService = context.services.getTrackerService()
+
+        try {
+            trackerService.resumeLogger(GpxListReaderXml(file, AutoPause.NULL).gpxList)
+        } catch (e: IOException) {
+            AppLog.e(this, e)
+        } catch (e: IllegalStateException) {
+            AppLog.e(this, e)
+        }
     }
 
     /**


### PR DESCRIPTION
This allows resuming a previous log file, for example after a crash or if resuming a long ride on the next day.
    
This is an early draft.  It barely works, but it's a quick'n'dirty hack.