### PR TITLE
aat-lib/gpx/attributes: add windowed speed and power attributes

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/activities/FileContentActivity.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/activities/FileContentActivity.kt
@@ -38,6 +38,7 @@ import ch.bailu.aat_lib.description.PauseDescription
 import ch.bailu.aat_lib.description.TimeApDescription
 import ch.bailu.aat_lib.description.TimeDescription
 import ch.bailu.aat_lib.description.TrackSizeDescription
+import ch.bailu.aat_lib.description.WindowSpeedDescription
 import ch.bailu.aat_lib.dispatcher.usage.UsageTrackerInterface
 import ch.bailu.aat_lib.gpx.information.InfoID
 
@@ -115,7 +116,8 @@ class FileContentActivity : AbsFileContentActivity() {
                 ContentDescriptions(
                     AverageSpeedDescription(storage),
                     AverageSpeedDescriptionAP(storage),
-                    MaximumSpeedDescription(storage)
+                    WindowSpeedDescription(storage),
+                    MaximumSpeedDescription(storage),
                 ),
                 CaloriesDescription(storage),
                 ContentDescriptions(
@@ -136,6 +138,7 @@ class FileContentActivity : AbsFileContentActivity() {
                 ),
                 ContentDescriptions(
                     IndexedAttributeDescription.AveragePower(),
+                    IndexedAttributeDescription.WindowPower(),
                     IndexedAttributeDescription.MaxPower(),
                 ),
                 TrackSizeDescription()

--- a/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/toplevel/DetailView.kt
+++ b/aat-gtk/src/main/kotlin/ch/bailu/aat_gtk/view/toplevel/DetailView.kt
@@ -27,6 +27,7 @@ import ch.bailu.aat_lib.description.PauseDescription
 import ch.bailu.aat_lib.description.TimeApDescription
 import ch.bailu.aat_lib.description.TimeDescription
 import ch.bailu.aat_lib.description.TrackSizeDescription
+import ch.bailu.aat_lib.description.WindowSpeedDescription
 import ch.bailu.aat_lib.dispatcher.DispatcherInterface
 import ch.bailu.aat_lib.dispatcher.filter.SelectFilter
 import ch.bailu.aat_lib.dispatcher.usage.UsageTrackerInterface
@@ -69,7 +70,8 @@ class DetailView(dispatcher: DispatcherInterface, usageTracker: UsageTrackerInte
             ContentDescriptions(
                 AverageSpeedDescription(storage),
                 AverageSpeedDescriptionAP(storage),
-                MaximumSpeedDescription(storage)
+                WindowSpeedDescription(storage),
+                MaximumSpeedDescription(storage),
             ),
             CaloriesDescription(storage),
             ContentDescriptions(
@@ -90,6 +92,7 @@ class DetailView(dispatcher: DispatcherInterface, usageTracker: UsageTrackerInte
             ),
             ContentDescriptions(
                 IndexedAttributeDescription.AveragePower(),
+                IndexedAttributeDescription.WindowPower(),
                 IndexedAttributeDescription.MaxPower(),
             ),
             TrackSizeDescription()

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/IndexedAttributeDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/IndexedAttributeDescription.kt
@@ -2,6 +2,7 @@ package ch.bailu.aat_lib.description
 
 import ch.bailu.aat_lib.gpx.information.GpxInformation
 import ch.bailu.aat_lib.gpx.attributes.SampleRate
+import ch.bailu.aat_lib.gpx.attributes.TimeWindowAttributes
 import ch.bailu.aat_lib.resources.Res
 
 open class IndexedAttributeDescription(
@@ -61,5 +62,11 @@ open class IndexedAttributeDescription(
         "Max " + Res.str().sensor_power(),
         PowerDescription.UNIT,
         SampleRate.Power.INDEX_MAX_POWER
+    )
+
+    class WindowPower : IndexedAttributeDescription(
+        "10' " + Res.str().sensor_power(),
+        PowerDescription.UNIT,
+        TimeWindowAttributes.INDEX_WINDOW_POWER
     )
 }

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/WindowSpeedDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/WindowSpeedDescription.kt
@@ -1,0 +1,16 @@
+package ch.bailu.aat_lib.description
+
+import ch.bailu.aat_lib.gpx.attributes.TimeWindowAttributes
+import ch.bailu.aat_lib.gpx.information.GpxInformation
+import ch.bailu.aat_lib.preferences.StorageInterface
+import ch.bailu.aat_lib.resources.Res
+
+class WindowSpeedDescription(storage: StorageInterface) : SpeedDescription(storage, FormatDisplay.f().decimal2) {
+    override fun getLabel(): String {
+        return "10' " + Res.str().average()
+    }
+
+    override fun onContentUpdated(iid: Int, info: GpxInformation) {
+        setCache(info.getAttributes().getAsFloat(TimeWindowAttributes.INDEX_WINDOW_SPEED))
+    }
+}

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/attributes/GpxListAttributes.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/attributes/GpxListAttributes.kt
@@ -90,7 +90,8 @@ class GpxListAttributes(vararg attr: GpxSubAttributes) :
                 SampleRate.HeartRate(),
                 SampleRate.Power(),
                 StepsRate(),
-                Steps()
+                Steps(),
+                TimeWindowAttributes(),
             )
         }
 

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/attributes/TimeWindowAttributes.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/attributes/TimeWindowAttributes.kt
@@ -1,0 +1,103 @@
+package ch.bailu.aat_lib.gpx.attributes
+
+import ch.bailu.aat_lib.gpx.GpxPointNode
+
+/**
+ * Rolling 10-minute averages for speed and power.
+ *
+ * Maintains a sliding window over the [GpxPointNode]s,
+ * accumulating distance, time, and power×time as each point is added via
+ * [update]. When the window exceeds 10 minutes, [trim] pops entries
+ * from the front.
+ */
+class TimeWindowAttributes : GpxSubAttributes(KEYS) {
+
+    private class Sample(val timeMillis: Long, val distance: Float, val energy: Double)
+
+    private val samples = ArrayDeque<Sample>()
+
+    /** Accumulated time within the window, in milliseconds. */
+    private var windowTimeMillis = 0L
+
+    /** Accumulated distance within the window, in metres. */
+    private var distance = 0f
+
+    /** Accumulated energy (sum of watts × milliseconds) within the window. */
+    private var energy = 0.0
+
+    override fun get(keyIndex: Int): String {
+        return when (keyIndex) {
+            INDEX_WINDOW_SPEED -> getAsFloat(keyIndex).toString()
+            INDEX_WINDOW_POWER -> getAsInteger(keyIndex).toString()
+            else -> NULL_VALUE
+        }
+    }
+
+    override fun getAsFloat(keyIndex: Int): Float {
+        if (keyIndex == INDEX_WINDOW_SPEED && windowTimeMillis > 0) {
+            return distance * 1000f / windowTimeMillis
+        }
+        return 0f
+    }
+
+    override fun getAsInteger(keyIndex: Int): Int {
+        if (keyIndex == INDEX_WINDOW_POWER && windowTimeMillis > 0) {
+            return (energy / windowTimeMillis).toInt()
+        }
+        return 0
+    }
+
+    override fun update(point: GpxPointNode, autoPause: Boolean): Boolean {
+        if (autoPause)
+            return autoPause
+
+        val timeDelta = point.getTimeDelta()
+        if (timeDelta <= 0 || timeDelta > MAX_TIME_DELTA)
+            return autoPause
+
+        val dist = point.getDistance()
+
+        val attr = point.getAttributes()
+        val sampleEnergy = if (attr.hasKey(PowerAttributes.KEY_INDEX_POWER)) {
+            attr.getAsFloat(PowerAttributes.KEY_INDEX_POWER).toDouble() * timeDelta
+        } else {
+            0.0
+        }
+
+        windowTimeMillis += timeDelta
+        distance += dist
+        energy += sampleEnergy
+
+        samples.addLast(Sample(timeDelta, dist, sampleEnergy))
+        trim()
+
+        return autoPause
+    }
+
+    private fun trim() {
+        while (samples.size > 1 && windowTimeMillis > WINDOW_MILLIS) {
+            val s = samples.removeFirst()
+            windowTimeMillis -= s.timeMillis
+            distance -= s.distance
+            energy -= s.energy
+        }
+    }
+
+    companion object {
+        private const val WINDOW_MILLIS = 600_000L // 10 minutes
+
+        /**
+         * Skip updates when timeDelta is larger than this number of
+         * milliseconds.
+         */
+        private const val MAX_TIME_DELTA = 10_000L
+
+        private val KEYS = Keys()
+
+        @JvmField
+        val INDEX_WINDOW_SPEED = KEYS.add("WindowSpeed")
+
+        @JvmField
+        val INDEX_WINDOW_POWER = KEYS.add("WindowPower")
+    }
+}

--- a/aat-lib/src/test/kotlin/ch/bailu/aat_lib/file/xml/parser/gpx/TestGpxListReaderXml.kt
+++ b/aat-lib/src/test/kotlin/ch/bailu/aat_lib/file/xml/parser/gpx/TestGpxListReaderXml.kt
@@ -16,7 +16,7 @@ class TestGpxListReaderXml {
         Assertions.assertEquals(1855, reader.gpxList.pointList.size())
 
         val attributes = reader.gpxList.getDelta().getAttributes()
-        Assertions.assertEquals(17, attributes.size())
+        Assertions.assertEquals(19, attributes.size())
 
         Assertions.assertEquals(false, attributes.hasKey(Keys.toIndex("SomeRandomKey")))
 


### PR DESCRIPTION
For now, the window is hard-coded to 10 minutes, but we may make this configurable at some point.
