### PR TITLE
android/CockpitActivity: add "previous" button

### DIFF
--- a/aat-android/src/main/kotlin/ch/bailu/aat/activities/CockpitActivity.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/activities/CockpitActivity.kt
@@ -90,8 +90,7 @@ class CockpitActivity : AbsKeepScreenOnActivity() {
 
     private fun createButtonBar(mv: MultiView): ControlBar {
         val bar = MainControlBar(this)
-
-        bar.addActivityCycle(this)
+        bar.addMvPrevious(mv)
         bar.addMvNext(mv)
         if (AppLayout.haveExtraSpaceGps(this)) {
             bar.addGpsState(this)

--- a/aat-android/src/main/kotlin/ch/bailu/aat/activities/CockpitSplitActivity.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/activities/CockpitSplitActivity.kt
@@ -133,7 +133,7 @@ class CockpitSplitActivity : AbsKeepScreenOnActivity() {
 
     private fun createButtonBar(mv: MultiView): ControlBar {
         val bar = MainControlBar(this)
-        bar.addActivityCycle(this)
+        bar.addMvPrevious(mv)
         bar.addMvNext(mv)
         if (AppLayout.haveExtraSpaceGps(this)) {
             bar.addGpsState(this)

--- a/aat-android/src/main/kotlin/ch/bailu/aat/views/bar/MainControlBar.kt
+++ b/aat-android/src/main/kotlin/ch/bailu/aat/views/bar/MainControlBar.kt
@@ -58,7 +58,7 @@ class MainControlBar(acontext: AbsDispatcher, orientation: Int = HORIZONTAL, but
         add(MultiViewNextButton(mv, theme), size)
     }
 
-    private fun addMvPrevious(mv: MultiView, size: Int) {
+    fun addMvPrevious(mv: MultiView, size: Int = controlSize) {
         addImageButton(
             R.drawable.go_previous_inverse,
             size


### PR DESCRIPTION
Replace the (compile-time disabled) "cycle" button with a "previous page" button.  This button is useful go switch quickly between two adjacent pages.