### PR TITLE
GpxListIterator: fix primer nodes capturing stale list head

### DIFF
--- a/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/GpxListIterator.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/gpx/GpxListIterator.kt
@@ -6,11 +6,15 @@ import ch.bailu.aat_lib.gpx.segmented_list.SegmentNode
 
 class GpxListIterator(private val track: GpxList) {
     private inner class PointPrimerNode : GpxPointFirstNode(GpxPoint.NULL, GpxAttributesNull.NULL) {
-        override var next = track.pointList.first
+        override var next: Node?
+            get() = track.pointList.first
+            set(_) {}
     }
 
     private inner class SegmentPrimerNode : GpxSegmentNode(PointPrimerNode()) {
-        override var next = track.segmentList.first
+        override var next: Node?
+            get() = track.segmentList.first
+            set(_) {}
     }
 
     private var point: GpxPointNode = PointPrimerNode()


### PR DESCRIPTION
The Java-to-Kotlin conversion in PR #202 changed the primer node getNext() overrides from dynamic methods into stored properties (override var next = ...), which captured the list's first element once at construction time. When GpxListWriter creates the iterator on an initially empty list, the primer's next stays null permanently, so writeNewPoints() never iterates and no points are written to the GPX log file.

Fix by using computed properties that read the current list head on every access, matching the original Java behavior.

Regression introduced in https://github.com/bailuk/AAT/pull/202