### PR TITLE
lib/Dispatcher: eliminate the HashMap.containsKey() call

### DIFF
--- a/aat-lib/src/main/java/ch/bailu/aat_lib/dispatcher/Dispatcher.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/dispatcher/Dispatcher.kt
@@ -19,10 +19,12 @@ class Dispatcher : DispatcherInterface {
     }
 
     private fun getTargetList(iid: Int): TargetList {
-        if (!targets.containsKey(iid)) {
-            targets[iid] = TargetList()
+        var list = targets[iid]
+        if (list == null) {
+            list = TargetList()
+            targets[iid] = list
         }
-        return targets[iid]!!
+        return list
     }
 
     override fun addSource(source: SourceInterface) {


### PR DESCRIPTION
This call is useless; instead, call HashMap.get() and handle the `null` condition.  This optimizes one HashMap lookup away.