### PR TITLE
lib/description: remove unnecessary `InfoID` checks

### DIFF
--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/CadenceDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/CadenceDescription.kt
@@ -31,7 +31,7 @@ class CadenceDescription : ContentDescription() {
 
     override fun onContentUpdated(iid: Int,  info: GpxInformation) {
         val haveSensor = SensorState.isConnected(InfoID.CADENCE_SENSOR)
-        if (iid == InfoID.CADENCE_SENSOR && haveSensor) {
+        if (haveSensor) {
             val hasContact = info.getAttributes().getAsBoolean(CadenceSpeedAttributes.KEY_INDEX_CONTACT)
             label = if (hasContact) {
                 labelDefault

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/HeartRateDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/HeartRateDescription.kt
@@ -29,7 +29,7 @@ class HeartRateDescription : ContentDescription() {
 
     override fun onContentUpdated(iid: Int, info: GpxInformation) {
         val haveSensor = SensorState.isConnected(InfoID.HEART_RATE_SENSOR)
-        if (iid == InfoID.HEART_RATE_SENSOR && haveSensor) {
+        if (haveSensor) {
             val bpm = info.getAttributes()[HeartRateAttributes.KEY_INDEX_BPM]
             val contact = info.getAttributes()[HeartRateAttributes.KEY_INDEX_CONTACT]
             value = bpm

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/PowerDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/PowerDescription.kt
@@ -32,7 +32,7 @@ class PowerDescription : ContentDescription() {
 
     override fun onContentUpdated(iid: Int, info: GpxInformation) {
         val haveSensor = SensorState.isConnected(InfoID.POWER_SENSOR)
-        if (iid == InfoID.POWER_SENSOR && haveSensor) {
+        if (haveSensor) {
             val hasContact = info.getAttributes().getAsBoolean(CadenceSpeedAttributes.KEY_INDEX_CONTACT)
             label = if (hasContact) {
                 labelDefault

--- a/aat-lib/src/main/java/ch/bailu/aat_lib/description/StepRateDescription.kt
+++ b/aat-lib/src/main/java/ch/bailu/aat_lib/description/StepRateDescription.kt
@@ -25,7 +25,7 @@ class StepRateDescription : ContentDescription() {
 
     override fun onContentUpdated(iid: Int, info: GpxInformation) {
         val haveSensor = SensorState.isConnected(InfoID.STEP_COUNTER_SENSOR)
-        if (iid == InfoID.STEP_COUNTER_SENSOR && haveSensor) {
+        if (haveSensor) {
             value = info.getAttributes()[StepCounterAttributes.KEY_INDEX_STEPS_RATE]
             unit = UNIT + " (" + info.getAttributes()[StepCounterAttributes.KEY_INDEX_STEPS_TOTAL] + ")"
         } else {


### PR DESCRIPTION
These ContentDescription are registed only with a single `InfoID` and thus `Dispatcher` only ever passes this one `InfoID` to onContentUpdated().